### PR TITLE
ci: Go 1.26 (Workflows + go.mod)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.25' ]
+        go-version: [ '1.26' ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,14 @@ jobs:
       - name: Start TimescaleDB
         run: |
           docker run -d --network=host --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg16
-          # Wait for the database to be ready
-          until docker exec timescaledb pg_isready -U postgres; do sleep 1; done
+          # Auf den TCP-Listener (5432) warten, nicht nur den lokalen Socket:
+          # das HA-Image oeffnet den Unix-Socket frueher als den TCP-Port, sonst
+          # bekommt die App 'connection refused'. -h/-p erzwingt die TCP-Pruefung.
+          for i in $(seq 1 60); do
+            docker exec timescaledb pg_isready -h 127.0.0.1 -p 5432 -U postgres && break
+            echo "warte auf TimescaleDB (TCP 5432)... ($i)"; sleep 2
+          done
+          docker exec timescaledb pg_isready -h 127.0.0.1 -p 5432 -U postgres
       - name: Run databridge
         run: |
           docker run --rm \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [ '1.25' ]
+        go-version: [ '1.26' ]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Go ${{ matrix.go-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 FROM golang:${GO_VERSION} AS builder
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Talk-Point/databridge
 
-go 1.25
+go 1.26
 
 require (
 	github.com/lib/pq v1.10.9


### PR DESCRIPTION
Hebt die Go-Version auf 1.26 an: `go-version` in den Actions-Workflows und die `go`-Direktive in jeder go.mod (`toolchain`-Pin entfernt). Kein `go mod tidy`. Org-weite Angleichung, Tracking: Talk-Point/IT#15822.